### PR TITLE
Atualização no handler de navegação.

### DIFF
--- a/ekko-lightbox.js
+++ b/ekko-lightbox.js
@@ -113,11 +113,11 @@ const Lightbox = (($) => {
 				if (this._config.showArrows && this._$galleryItems.length > 1) {
 					this._$lightboxContainer.append(`<div class="ekko-lightbox-nav-overlay"><a href="#">${this._config.leftArrow}</a><a href="#">${this._config.rightArrow}</a></div>`)
 					this._$modalArrows = this._$lightboxContainer.find('div.ekko-lightbox-nav-overlay').first()
-					this._$lightboxContainer.on('click', 'a:first-child', event => {
+					this._$modalArrows.on('click', 'a:first-child', event => {
 						event.preventDefault()
 						return this.navigateLeft()
 					})
-					this._$lightboxContainer.on('click', 'a:last-child', event => {
+					this._$modalArrows.on('click', 'a:last-child', event => {
 						event.preventDefault()
 						return this.navigateRight()
 					})


### PR DESCRIPTION
O evento de clique estava sendo escutado no `_$lightboxContainer` ao invés do `_$modalArrows` o que fazia com que qualquer link filho do container fosse entendido como um link de navegação, o que não é o caso quando temos dentro do modal um link externo, por exemplo. Se possível atualize pra gente as versões do arquivo que estão no `/dist` também ;)

Grato!